### PR TITLE
[test] Integrate an existing testcase upon build by Catkin.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,5 +18,6 @@ install(PROGRAMS scripts/rqt_tf_tree
 )
 
 if (CATKIN_ENABLE_TESTING)
-  catkin_add_nosetests(test/dotcode_tf_test.py)
+  catkin_add_nosetests(test/dotcode_tf_test.py
+     DEPENDENCIES ${${PROJECT_NAME}_EXPORTED_TARGETS})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,3 +16,7 @@ install(DIRECTORY resource
 install(PROGRAMS scripts/rqt_tf_tree
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+
+if (CATKIN_ENABLE_TESTING)
+  catkin_add_nosetests(test/dotcode_tf_test.py)
+endif()

--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,6 @@
   <version>0.5.8</version>
   <description>rqt_tf_tree provides a GUI plugin for visualizing the ROS TF frame tree.</description>
   <author>Thibault Kruse</author>
-  <maintainer email="ablasdel@gmail.com">Aaron Blasdel</maintainer>
   <maintainer email="gm130s@gmail.com">Isaac I.Y. Saito</maintainer>
   <maintainer email="peter9606@gmail.com">Peter Han</maintainer>
 

--- a/src/rqt_tf_tree/dotcode_tf.py
+++ b/src/rqt_tf_tree/dotcode_tf.py
@@ -85,7 +85,7 @@ class RosTfTreeDotcodeGenerator(object):
             self.rankdir = rankdir
             self.ranksep = ranksep
 
-        #generate new dotcode
+        # generate new dotcode
         if force_refresh or self.dotcode is None or selection_changed:
             if self.listen_duration > 0:
                 time.sleep(self.listen_duration)
@@ -108,7 +108,6 @@ class RosTfTreeDotcodeGenerator(object):
             self.dotcode_factory.add_node_to_graph(graph, "No tf data received")
             return graph
 
-
         for frame_dict in data:
             tf_frame_values = data[frame_dict]
             if not tf_frame_values['parent'] in data:
@@ -119,7 +118,7 @@ class RosTfTreeDotcodeGenerator(object):
             self.dotcode_factory.add_node_to_graph(
                 graph, frame_dict, shape='ellipse')
 
-            edge_label= '"Broadcaster: %s\\n' % str(tf_frame_values['broadcaster'])
+            edge_label = '"Broadcaster: %s\\n' % str(tf_frame_values['broadcaster'])
             edge_label += 'Average rate: %s\\n' % str(tf_frame_values['rate'])
             edge_label += 'Buffer length: %s\\n' % str(tf_frame_values['buffer_length'])
             edge_label += 'Most recent transform: %s\\n' % str(tf_frame_values['most_recent_transform'])

--- a/src/rqt_tf_tree/tf_tree.py
+++ b/src/rqt_tf_tree/tf_tree.py
@@ -33,7 +33,6 @@
 from __future__ import division
 import os
 
-
 import rospy
 import rospkg
 

--- a/test/dotcode_tf_test.py
+++ b/test/dotcode_tf_test.py
@@ -32,12 +32,11 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
-import rospkg
 
 import tf2_ros
 
 # get mock from pypi as 'mock'
-from mock import Mock, MagicMock, patch
+from mock import Mock, patch
 
 from rqt_tf_tree.dotcode_tf import RosTfTreeDotcodeGenerator
 

--- a/test/dotcode_tf_test.py
+++ b/test/dotcode_tf_test.py
@@ -34,8 +34,7 @@
 import unittest
 import rospkg
 
-import tf
-from tf.srv import *
+import tf2_ros
 
 # get mock from pypi as 'mock'
 from mock import Mock, MagicMock, patch
@@ -46,7 +45,7 @@ from rqt_tf_tree.dotcode_tf import RosTfTreeDotcodeGenerator
 class DotcodeGeneratorTest(unittest.TestCase):
 
     def test_generate_dotcode(self):
-        with patch('tf.TransformListener') as tf:
+        with patch('tf2_ros.TransformListener') as tf:
             def tf_srv_fun_mock():
                 return tf
 

--- a/test/dotcode_tf_test.py
+++ b/test/dotcode_tf_test.py
@@ -55,27 +55,27 @@ class DotcodeGeneratorTest(unittest.TestCase):
                                             'most_recent_transform': 'fr_most_recent_transform',
                                             'oldest_transform': 'fr_oldest_transform',}}
             tf.frame_yaml = str(yaml_data)
-            
+
             factoryMock = Mock()
             graphMock = Mock()
             timeMock = Mock()
             timerMock = Mock()
-            timerMock.now.return_value=timeMock
-            timeMock.to_sec.return_value=42
+            timerMock.now.return_value = timeMock
+            timeMock.to_sec.return_value = 42
 
             yamlmock = Mock()
             yamlmock.load.return_value = yaml_data
-            
+
             factoryMock.create_dot.return_value = "foo"
             factoryMock.get_graph.return_value = graphMock
-            
+
             gen = RosTfTreeDotcodeGenerator(0)
             graph = gen.generate_dotcode(factoryMock, tf_srv_fun_mock, timerMock)
 
             timerMock.now.assert_called_with()
             timeMock.to_sec.assert_called_with()
             factoryMock.create_dot.assert_called_with(graphMock)
-            
+
             self.assertEqual(graph, 'foo')
 
 if __name__ == '__main__':

--- a/test/dotcode_tf_test.py
+++ b/test/dotcode_tf_test.py
@@ -79,3 +79,6 @@ class DotcodeGeneratorTest(unittest.TestCase):
             factoryMock.create_dot.assert_called_with(graphMock)
             
             self.assertEqual(graph, 'foo')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
There's a testcase in `rqt_tf_tree/test` folder but seems to have not been integrated.

I'm not entirely sure about d9f53ff but without this the following error was recorded:

```
 $ catkin_test_results
 build/rqt_tf_tree/test_results/rqt_tf_tree/nosetests-test.dotcode_tf_test.py.xml: 1 tests, 1 errors, 0 failures, 0 skipped
 Summary: 1 tests, 1 errors, 0 failures, 0 skipped
 $ more build/rqt_tf_tree/test_results/rqt_tf_tree/nosetests-test.dotcode_tf_test.py.xml
 <?xml version="1.0" encoding="UTF-8"?><testsuite name="nosetests" tests="1" errors="1" failures="0" skip="0"><testcase classname="nose.failure.Failure" name="runTest" time="0.000"><error type="exceptions.
ImportError" message="No module named rqt_tf_tree.dotcode_tf&#10;-------------------- &gt;&gt; begin captured logging &lt;&lt; --------------------&#10;rospy.topics: INFO: topicmanager initialized&#10;--------------------- &gt;&gt; end captured logging &lt;&lt; ---------------------"><![CDATA[  File "/usr/lib/python2.7/unittest/case.py", line 329, in run    testMethod()
      File "/usr/lib/python2.7/dist-packages/nose/loader.py", line 418, in loadTestsFromName
          addr.filename, addr.module)
	    File "/usr/lib/python2.7/dist-packages/nose/importer.py", line 47, in importFromPath
	        return self.importFromDir(dir_path, fqname)
		  File "/usr/lib/python2.7/dist-packages/nose/importer.py", line 94, in importFromDir
		      mod = load_module(part_fqname, fh, filename, desc)
		        File "/home/n130s/link/ROS/indigo_trusty/cws_viz/src/ros-visualization/rqt_tf_tree/test/dotcode_tf_test.py", line 43, in <module>
    from rqt_tf_tree.dotcode_tf import RosTfTreeDotcodeGenerator
    'No module named rqt_tf_tree.dotcode_tf\n-------------------- >> begin captured logging << -----------
```