### PR TITLE
add node explicitly

### DIFF
--- a/src/rqt_tf_tree/dotcode_tf.py
+++ b/src/rqt_tf_tree/dotcode_tf.py
@@ -116,6 +116,8 @@ class RosTfTreeDotcodeGenerator(object):
             self.dotcode_factory.add_node_to_graph(graph,
                                                    str(tf_frame_values['parent']),
                                                    shape='ellipse')
+            self.dotcode_factory.add_node_to_graph(
+                graph, frame_dict, shape='ellipse')
 
             edge_label= '"Broadcaster: %s\\n' % str(tf_frame_values['broadcaster'])
             edge_label += 'Average rate: %s\\n' % str(tf_frame_values['rate'])


### PR DESCRIPTION
Fixes #4.

The call to `add_edge_to_graph` adds the second node implicitly which will escape the label of the node. Since that is undesired the node needs to be added explicitly before.