### PR TITLE
[ros2] remove unused dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,16 +12,12 @@
   <url type="repository">https://github.com/ros-visualization/rqt_tf_tree</url>
   <url type="bugtracker">https://github.com/ros-visualization/rqt_tf_tree/issues</url>
 
-  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</exec_depend>
   <exec_depend>qt_dotgraph</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rqt_graph</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
-  <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_msgs</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
 


### PR DESCRIPTION
`rospkg` isn't used and poses a problem when trying to install the ROS 2 package in parallel with ROS 1 using Python 2.