### PR TITLE
[ros1] remove unused dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</exec_depend>
@@ -23,7 +22,6 @@
   <exec_depend>rqt_graph</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
-  <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_msgs</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
 


### PR DESCRIPTION
Backport of #14.

Nothing from either of the two dependencies is used directly by this package.