### PR TITLE
ROS Noetic 20.04 Fix dot save according to the PyQt5

### DIFF
--- a/src/rqt_tf_tree/tf_tree.py
+++ b/src/rqt_tf_tree/tf_tree.py
@@ -216,7 +216,7 @@ class RosTfTree(QObject):
         if not file.open(QIODevice.WriteOnly | QIODevice.Text):
             return
 
-        file.write(self._current_dotcode)
+        file.write(bytes(self._current_dotcode, 'utf-8'))
         file.close()
 
     def _save_svg(self):


### PR DESCRIPTION
Couldn't save a dot graph without this with Noetic
http://pyqt.sourceforge.net/Docs/PyQt5/incompatibilities.html