### PR TITLE
fix breaking rqt_tree and update script installation

### DIFF
--- a/scripts/rqt_tf_tree
+++ b/scripts/rqt_tf_tree
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-
-import sys
-
-from rqt_gui.main import Main
-
-main = Main()
-sys.exit(main.main(sys.argv, standalone='rqt_tf_tree.tf_tree.RosTfTree'))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/rqt_tf_tree
+[install]
+install_scripts=$base/lib/rqt_tf_tree

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     license='BSD',
     entry_points={
         'console_scripts': [
-            'rqt_tf_tree = rqt_tf_tree.main:main'
+            'rqt_tf_tree = ' + package_name + '.main:main'
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
         ('share/' + package_name + '/resource', ['resource/RosTfTree.ui']),
         ('share/' + package_name, ['package.xml']),
         ('share/' + package_name, ['plugin.xml']),
-        ('lib/' + package_name, ['scripts/rqt_tf_tree'])
     ],
     install_requires=['setuptools'],
     zip_safe=True,
@@ -32,5 +31,9 @@ setup(
         'rqt_tf_tree provides a GUI plugin for visualizing the ROS TF frame tree.'
     ),
     license='BSD',
-    scripts=['scripts/rqt_tf_tree'],
+    entry_points={
+        'console_scripts': [
+            'rqt_tf_tree = rqt_tf_tree.main:main'
+        ],
+    },
 )

--- a/src/rqt_tf_tree/dotcode_tf.py
+++ b/src/rqt_tf_tree/dotcode_tf.py
@@ -93,7 +93,7 @@ class RosTfTreeDotcodeGenerator(object):
             self.listen_duration = 0
 
             yaml_data = tf2_frame_srv.call(FrameGraph.Request()).frame_yaml
-            data = yaml_parser.full_load(yaml_data)
+            data = yaml_parser.safe_load(yaml_data)
             self.graph = self.generate(data, timer.now().nanoseconds / rclpy.time.CONVERSION_CONSTANT)
             self.dotcode = self.dotcode_factory.create_dot(self.graph)
 

--- a/src/rqt_tf_tree/dotcode_tf.py
+++ b/src/rqt_tf_tree/dotcode_tf.py
@@ -93,7 +93,7 @@ class RosTfTreeDotcodeGenerator(object):
             self.listen_duration = 0
 
             yaml_data = tf2_frame_srv.call(FrameGraph.Request()).frame_yaml
-            data = yaml_parser.load(yaml_data)
+            data = yaml_parser.full_load(yaml_data)
             self.graph = self.generate(data, timer.now().nanoseconds / rclpy.time.CONVERSION_CONSTANT)
             self.dotcode = self.dotcode_factory.create_dot(self.graph)
 

--- a/src/rqt_tf_tree/main.py
+++ b/src/rqt_tf_tree/main.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import sys
+
+from rqt_gui.main import Main
+
+
+def main():
+    main = Main()
+    sys.exit(main.main(sys.argv, standalone='rqt_tf_tree.tf_tree.RosTfTree'))
+
+
+if __name__ == '__main__':
+    main()

--- a/src/rqt_tf_tree/tf_tree.py
+++ b/src/rqt_tf_tree/tf_tree.py
@@ -71,7 +71,7 @@ class RosTfTree(QObject):
         # self.dotcode_factory = PygraphvizFactory()
         # generator builds rosgraph
         self.dotcode_generator = RosTfTreeDotcodeGenerator()
-        self.tf2_buffer_ = tf2_ros.Buffer()
+        self.tf2_buffer_ = tf2_ros.Buffer(node=self._node)
         self.tf2_listener_ = tf2_ros.TransformListener(self.tf2_buffer_, self._node)
 
         # dot_to_qt transforms into Qt elements using dot layout


### PR DESCRIPTION
Fixes on ros2 `rqt_tf_tree`.

- This fix is mainly related to https://github.com/ros-visualization/rqt_tf_tree/issues/32 . Alongside sneaking in a fix on https://github.com/ros-visualization/rqt_tf_tree/issues/29.

- Also, updated the script installation (setup.py) according to the convention as https://github.com/ros-visualization/rqt_console/tree/ros2

- If this works, would appreciate if `rqt_tf_tree` can be available as binary dist, as this is one of the most useful viz tool to have on ROS. https://github.com/ros-visualization/rqt_tf_tree/issues/31

Signed-off-by: youliang <tan_you_liang@hotmail.com>