### PR TITLE
Use S_TO_NS instead of rclpy.time.CONVERSION_CONSTANT

### DIFF
--- a/src/rqt_tf_tree/dotcode_tf.py
+++ b/src/rqt_tf_tree/dotcode_tf.py
@@ -34,6 +34,7 @@ import time
 import rclpy
 import yaml
 
+from rclpy.constants import S_TO_NS
 from tf2_msgs.srv import FrameGraph
 
 
@@ -94,7 +95,7 @@ class RosTfTreeDotcodeGenerator(object):
 
             yaml_data = tf2_frame_srv.call(FrameGraph.Request()).frame_yaml
             data = yaml_parser.safe_load(yaml_data)
-            self.graph = self.generate(data, timer.now().nanoseconds / rclpy.time.CONVERSION_CONSTANT)
+            self.graph = self.generate(data, timer.now().nanoseconds / S_TO_NS)
             self.dotcode = self.dotcode_factory.create_dot(self.graph)
 
         return self.dotcode


### PR DESCRIPTION
This addresses the same issue as #47.
Due to stall in #47 and breaking problem this PR is created.
But instead of using hardcoded number, using S_TO_NS constant from rclpy.constants. 