### PR TITLE
Fixed pytest for buildfarm

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,8 @@
   <url type="repository">https://github.com/ros-visualization/rqt_tf_tree</url>
   <url type="bugtracker">https://github.com/ros-visualization/rqt_tf_tree/issues</url>
 
+  <test_depend>python3-pytest</test_depend>
+
   <exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
   <exec_depend>qt_dotgraph</exec_depend>
   <exec_depend>rclpy</exec_depend>

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'rqt_tf_tree provides a GUI plugin for visualizing the ROS TF frame tree.'
     ),
     license='BSD',
+    tests_require=['pytest'],
     entry_points={
         'console_scripts': [
             'rqt_tf_tree = ' + package_name + '.main:main'


### PR DESCRIPTION
Without the __tests_require__ field in the setup.py the buildfarm writes "NO TESTS RAN" to the stderr with by colcon is considered an error.
This marks the build as failed even-though no tests ran.
The changes in this PR fixed the existing test and removes the dependency for "mock" which could also cause problems if the library is not installed.
So the code was changed to use "unittests" only which should be a default library.