### PR TITLE
Explicitly import clock to avoid test fail in Humble

### DIFF
--- a/src/rqt_tf_tree/dotcode_tf.py
+++ b/src/rqt_tf_tree/dotcode_tf.py
@@ -34,6 +34,7 @@ import time
 import rclpy
 import yaml
 
+from rclpy import clock
 from rclpy.constants import S_TO_NS
 from tf2_msgs.srv import FrameGraph
 


### PR DESCRIPTION
After activating the tests, Jazzy and Rolling are now working fine on the build farm.
However, Humble failed with the test with __module 'rclpy' has no attribute 'clock'__.
This can be fixed by explicitly importing clock.