### PR TITLE
Capability: Add CI 

### DIFF
--- a/.github/workflows/ici.yaml
+++ b/.github/workflows/ici.yaml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  rqt_robot_steering:
+    strategy:
+      matrix:
+        env:
+          - {ROS_DISTRO: jazzy, ROS_REPO: testing}
+          - {ROS_DISTRO: jazzy, ROS_REPO: main}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{matrix.env}}


### PR DESCRIPTION
# Targeted issues
- Running tests on CI is missing (pointed at https://github.com/ros-visualization/rqt_tf_tree/pull/52#pullrequestreview-3184400865)

# Approach
- Similar to a fellow rqt repo https://github.com/ros-visualization/rqt_robot_steering/pull/27, using industrial_ci for convenience.
