### PR TITLE
Replace SafeLoader monkey-patch with dedicated YAML loader subclass

### DIFF
--- a/src/rqt_tf_tree/dotcode_tf.py
+++ b/src/rqt_tf_tree/dotcode_tf.py
@@ -39,13 +39,11 @@ import yaml
 
 
 class _TfTreeYamlLoader(yaml.SafeLoader):
-    """Dedicated YAML loader for the FrameGraph payload.
+    """
+    YAML loader for the FrameGraph payload.
 
-    Stringifies integer mapping keys without polluting the global
-    yaml.SafeLoader — earlier revisions monkey-patched SafeLoader on every
-    refresh, which was non-idempotent and caused infinite recursion on the
-    second invocation (https://github.com/ros-visualization/rqt_tf_tree
-    issue tracker).
+    Stringifies integer mapping keys without monkey-patching the global
+    yaml.SafeLoader, which caused infinite recursion on repeat calls.
     """
 
 

--- a/src/rqt_tf_tree/dotcode_tf.py
+++ b/src/rqt_tf_tree/dotcode_tf.py
@@ -38,6 +38,26 @@ from tf2_msgs.srv import FrameGraph
 import yaml
 
 
+class _TfTreeYamlLoader(yaml.SafeLoader):
+    """Dedicated YAML loader for the FrameGraph payload.
+
+    Stringifies integer mapping keys without polluting the global
+    yaml.SafeLoader — earlier revisions monkey-patched SafeLoader on every
+    refresh, which was non-idempotent and caused infinite recursion on the
+    second invocation (https://github.com/ros-visualization/rqt_tf_tree
+    issue tracker).
+    """
+
+
+def _stringify_int_keys(loader, node, deep=False):
+    data = yaml.SafeLoader.construct_mapping(loader, node, deep)
+    return {(str(k) if isinstance(k, int) else k): data[k] for k in data}
+
+
+_TfTreeYamlLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _stringify_int_keys)
+
+
 class RosTfTreeDotcodeGenerator(object):
 
     def __init__(self, initial_listen_duration=1):
@@ -91,18 +111,7 @@ class RosTfTreeDotcodeGenerator(object):
 
             yaml_data = tf2_frame_srv.call(FrameGraph.Request()).frame_yaml
 
-            # Patch SafeLoader.construct_mapping only once. Re-patching would
-            # save the already-patched function as construct_mapping_org,
-            # causing it to call itself recursively (RecursionError).
-            if not hasattr(yaml.SafeLoader, 'construct_mapping_org'):
-                def default_tftree_construct_mapping(self, node, deep=False):
-                    data = self.construct_mapping_org(node, deep)
-                    return {(str(key) if isinstance(key, int) else key): data[key] for key in data}
-
-                yaml.SafeLoader.construct_mapping_org = yaml.SafeLoader.construct_mapping
-                yaml.SafeLoader.construct_mapping = default_tftree_construct_mapping
-
-            data = yaml_parser.safe_load(yaml_data)
+            data = yaml_parser.load(yaml_data, Loader=_TfTreeYamlLoader)
             self.graph = self.generate(data, timer.now().nanoseconds / S_TO_NS)
             self.dotcode = self.dotcode_factory.create_dot(self.graph)
 


### PR DESCRIPTION
## Bug

`rqt_tf_tree` crashes with `RecursionError` when the TF tree launched before nodes publishing `tf`.

```text
File ".../rqt_tf_tree/dotcode_tf.py", line 100, in default_tftree_construct_mapping
    data = self.construct_mapping_org(node, deep)
[Previous line repeated 984 more times]
RecursionError: maximum recursion depth exceeded
```

## Reproducer

1. `ros2 run rqt_tf_tree rqt_tf_tree`
2. Click **Refresh**.
3. Launch some tf publisher
4. Click **Refresh**.

Error fires automatically on first display when rqt is started before any TF
publisher exists; rqt internally retries dotcode generation, which triggers
the second invocation.

## Why the fix works

Previous code mutated `yaml.SafeLoader.construct_mapping` globally on every
call and unconditionally saved the "original" into `construct_mapping_org`.
After the second call, the saved "original" was itself the previous override,
so the override called itself — recursion.

The fix replaces the runtime mutation with a dedicated
`_TfTreeYamlLoader(yaml.SafeLoader)` subclass that registers the
int-key-stringifying mapping constructor once, at module import. No per-call
mutation → no idempotency concern → bug fixed by construction. Bonus: the
global `yaml.SafeLoader` is no longer polluted for other modules in the same
process.