### PR TITLE
Replaced the deprecated tests_require=['pytest']

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,11 @@ setup(
         'rqt_tf_tree provides a GUI plugin for visualizing the ROS TF frame tree.'
     ),
     license='BSD',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'rqt_tf_tree = ' + package_name + '.main:main'


### PR DESCRIPTION
Related with https://github.com/ros-visualization/rqt_tf_tree/issues/53