### PR TITLE
Add missing dependency on tf2_ros_py

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <exec_depend>rqt_gui_py</exec_depend>
   <exec_depend>tf2_msgs</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>tf2_ros_py</exec_depend>
 
   <test_depend condition="$ROS_PYTHON_VERSION == 2">python-mock</test_depend>
   <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-mock</test_depend>


### PR DESCRIPTION
Fails:
```
cd $(mktemp -d)
pixi init --channel conda-forge --channel https://prefix.dev/robostack-humble
pixi add ros-humble-ros2run ros-humble-rqt-tf-tree
pixi run ros2 run rqt_tf_tree rqt_tf_tree
```
Succeeds:
```
cd $(mktemp -d)
pixi init --channel conda-forge --channel https://prefix.dev/robostack-humble
pixi add ros-humble-ros2run ros-humble-rqt-tf-tree ros-humble-tf2-ros-py
pixi run ros2 run rqt_tf_tree rqt_tf_tree
```

Same result for all active ros distros